### PR TITLE
Fix feature props for export

### DIFF
--- a/tests/test_feature_format.py
+++ b/tests/test_feature_format.py
@@ -137,7 +137,7 @@ class TestGlobalFeatureFormat:
 
         rnd_feature_names = random.sample(list(available.keys()), k=min(len(available) - 1, 3))
 
-        props = feature_plugin.fill_properties({k: available[k] for k in rnd_feature_names})
+        props = feature_plugin.fill_properties({k: {} for k in rnd_feature_names})
 
         assert len(props) == len(rnd_feature_names)
 


### PR DESCRIPTION
Fixes error during feature table export in ilastik

In ilastik `fill_properties` can be called with empty dicts for the features and should, thus, actually fill them. Test adapted accordingly.

The feature description (`_feature_dict`) is now a bit more verbose (with separate entries for 2D and 3D features).