### PR TITLE
Update plugin to new ilastik plugin structure (without yapsy)

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,4 +41,6 @@ test:
   source_files:
     - tests
   requires:
-    - pytest
+    {% for dev_dep in pp.get('optional-dependencies')['dev'] %}
+    - {{ dev_dep.lower() }}
+    {% endfor %}

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,9 +4,9 @@ channels:
   - nodefaults
 
 dependencies:
-  - python 3.9.*
+  - python 3.13.*
   - pip
-  - ilastik
+  - ilastik-core
   - typing_extensions
   - pytest
   - sphericaltexture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphericaltexture_plugin"
-version = "0.0.3"
-authors = [{name="Oane Gros", email="oane.gros@embl.de" }]
+version = "0.0.5"
+authors = [{name="Aafke Gros", email="aafke.gros@embl.de" }]
 description = "Maps each object to a sphere/circle by mean intensity projection, and quantifies the distribution of the intensity signal in the projection through Spherical Harmonics/Fourier decomposition, or exposes polarization direction."
 readme = "README.md"
 
 # TODO: Add your dependencies here:
-dependencies = ["ilastik", "typing_extensions", "sphericaltexture"]
-requires-python = ">=3.9"
+dependencies = ["ilastik-core", "typing_extensions", "sphericaltexture"]
+requires-python = ">=3.10"
 
 
-[project.entry-points."ilastik.objectfeatures"]
-sphericaltexture_plugin = "sphericaltexture_plugin"
-
-[tool.setuptools.package-data]
-sphericaltexture_plugin = ["*.yapsy-plugin"]
+[project.entry-points."ilastik.objectfeature_plugins"]
+sphericaltexture_plugin = "sphericaltexture_plugin.objfeat_sphericaltexture:ObjFeatSphericalTexture"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,23 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphericaltexture_plugin"
-version = "0.0.5"
+version = "0.1.0"
 authors = [{name="Aafke Gros", email="aafke.gros@embl.de" }]
 description = "Maps each object to a sphere/circle by mean intensity projection, and quantifies the distribution of the intensity signal in the projection through Spherical Harmonics/Fourier decomposition, or exposes polarization direction."
 readme = "README.md"
+license = "MIT"
+license-files = [
+    "LICENSE",
+]
 
-# TODO: Add your dependencies here:
-dependencies = ["ilastik-core", "typing_extensions", "sphericaltexture"]
+dependencies = ["typing_extensions", "sphericaltexture"]
 requires-python = ">=3.10"
 
+[project.optional-dependencies]
+dev = ["pytest", "ilastik-core"]
+
+[tool.setuptools]
+packages = ["sphericaltexture_plugin"]
 
 [project.entry-points."ilastik.objectfeature_plugins"]
 sphericaltexture_plugin = "sphericaltexture_plugin.objfeat_sphericaltexture:ObjFeatSphericalTexture"

--- a/sphericaltexture_plugin/objfeat_sphericaltexture.py
+++ b/sphericaltexture_plugin/objfeat_sphericaltexture.py
@@ -16,7 +16,7 @@ class ObjFeatSphericalTexture(ObjectFeaturesPlugin):
     plugin_info = PluginInfo(
         name="Spherical Texture",
         author="Aafke Gros",
-        version="0.0.2",
+        version="0.1.0",
         description=textwrap.dedent("""
             Maps each object to a sphere/circle by mean intensity projection, and quantifies the distribution of the intensity
             signal in the projection through Spherical Harmonics/Fourier decomposition, or exposes polarization direction.

--- a/sphericaltexture_plugin/objfeat_sphericaltexture.py
+++ b/sphericaltexture_plugin/objfeat_sphericaltexture.py
@@ -1,35 +1,27 @@
-from typing import Dict, List
+import textwrap
+from typing import Dict
 
 from typing_extensions import NotRequired, TypedDict
 
 import numpy
-import numpy.typing as numpyt
 import vigra
-from ilastik.plugins.types import ObjectFeaturesPlugin
+from ilastik.plugins.types import ObjectFeaturesPlugin, FeatureDescription, PluginInfo
 
 from sphericaltexture import SphericalTextureGenerator
-
-
-class FeatureDescription(TypedDict):
-    displaytext: str
-    detailtext: str
-    tooltip: str
-    advanced: bool
-    group: NotRequired[str]
-    margin: NotRequired[int]
-    # features are assumed to be able to do 2D and 3D. If your feature
-    # cannot do one of them, you can mark those accordingly by setting
-    # one of those keys in the feature description
-    no_3D: NotRequired[bool]
-    no_2D: NotRequired[bool]
-    # if raw data is accessed for your feature, the most of the
-    channel_aware: NotRequired[bool]
 
 
 class ObjFeatSphericalTexture(ObjectFeaturesPlugin):
     """Plugins of this class calculate object features."""
 
-    name = "Spherical Texture"
+    plugin_info = PluginInfo(
+        name="Spherical Texture",
+        author="Aafke Gros",
+        version="0.0.2",
+        description=textwrap.dedent("""
+            Maps each object to a sphere/circle by mean intensity projection, and quantifies the distribution of the intensity
+            signal in the projection through Spherical Harmonics/Fourier decomposition, or exposes polarization direction.
+            """)
+    )
 
     _feature_dict: Dict[str, FeatureDescription] = {
         "Spherical Spectrum": {

--- a/sphericaltexture_plugin/objfeat_sphericaltexture.yapsy-plugin
+++ b/sphericaltexture_plugin/objfeat_sphericaltexture.yapsy-plugin
@@ -1,8 +1,0 @@
-[Core]
-Name = Spherical Texture
-Module = objfeat_sphericaltexture
-
-[Documentation]
-Author = Oane Gros
-Version = 0.0.2
-Description = Maps each object to a sphere/circle by mean intensity projection, and quantifies the distribution of the intensity signal in the projection through Spherical Harmonics/Fourier decomposition, or exposes polarization direction.


### PR DESCRIPTION
Adapt the spherical texture plugin to ilastik's new plugin structure.

Will ping you once there needs to be any action (review) here.

Background:
The ilastik plugin system was based on `yapsy` - a python library that is not maintained anymore and breaks for python>3.12. So we're migrating to using entrypoints for our plugin system, which doesn't require any other dependencies and should be more futureproof.